### PR TITLE
Fix heise.de main RSS feed

### DIFF
--- a/general/heise_de
+++ b/general/heise_de
@@ -1,19 +1,42 @@
 {
-	"name": "heise.de Ticker",
-	"url": "http://heise.de/newsticker/",
-	"match": "heise.de",
-	"author": "Matthias Bilger",
-	"stamp": 1419361984,
-	"config":{
-		"type": "xpath",
-		"xpath": "article",
-		"cleanup": [
-			"p[contains(@class,'news_datum')]",
-			"div[contains(@class,'readspeakerr')]",
-			"h1[contains(@class,'clear')]",
-			"noscript",
-			"comment()",
-			"script"
-		]
-	}
+        "name": "heise.de",
+        "url": "heise.de",
+        "stamp": 1599066467,
+        "author": "uqs",
+        "match": "heise.de",
+        "config": {
+                "type": "xpath",
+                "xpath": "article",
+                "reformat": [
+                        {
+                                "type": "regex",
+                                "pattern": "\/html$\/",
+                                "replace": "html?seite=all"
+                        }
+                ],
+                "modify": [
+                        {
+                                "type": "regex",
+                                "pattern": "\/<.?noscript>\/",
+                                "replace": ""
+                        },
+                        {
+                                "type": "regex",
+                                "pattern": "\/<.?a-lightbox[^>]*?>\/",
+                                "replace": ""
+                        }
+                ],
+                "cleanup": [
+                        "h1[contains(@class,'a-article-header__title')]",
+                        "div[contains(@class,'a-article-header__service')]",
+                        "figure[@class='branding']",
+                        "a-collapse[contains(@class,'a-box--collapsable')]",
+                        "a-teaser",
+                        "a-ad",
+                        "aside",
+                        "a-script",
+                        "a-img",
+                        "footer"
+                ]
+        }
 }


### PR DESCRIPTION
- h1 title is redundant with title in <head>
- always request ?seite=all to get multipage articles
- the regular <img src> element is hidden under noscript, so unhide that
- ... and drop a-img and other elements that can't work without CSS

We also need to strip the a-lightbox tags (but not their content). While
the web frontend as well as the overview page in the Android app would
show the <img> tag inside just fine, as soon as you read the article in
the Android app, the <img> inside <a-lightbox> would no longer be
rendered. ¯\_(ツ)_/¯

Please answer the following questions for yourself before submitting a pull request. **YOU MAY DELETE UNUSED SECTIONS.**

# Rule Submission

Website: heise.de

* [x] I have made the rule as simple as possible ( K.I.S.S )
* [x] I have run the rule myself for a period of time to spot any bugs