### PR TITLE
Add a recipe for oglaf.com

### DIFF
--- a/general/oglaf_com
+++ b/general/oglaf_com
@@ -1,0 +1,21 @@
+{
+        "name": "oglaf.com",
+        "url": "oglaf.com",
+        "stamp": 1599066621,
+        "author": "uqs",
+        "match": "oglaf.com",
+        "config": {
+                "type": "xpath",
+                "xpath": [
+                        "img[@id='strip']",
+                        "img[@id='strip']\/@title",
+                        "img[@id='strip']\/@alt"
+                ],
+                "multipage": {
+                        "xpath": "a[@class='button next' and contains(translate(@href, '1234567890', '@@@@@@@@@@'),'@\/')]",
+                        "append": true,
+                        "recursive": true
+                },
+                "join_element": "<br>"
+        }
+}


### PR DESCRIPTION
Shamelessly copied from other recipes and made the next button work for
multipage comic strips.

BEWARE: it's always the same Next button, so don't test this on an older
comic, as you'll scrape all of oglaf.com in one go ... we would need
some conditional on the img filename or the URL ending in <digit>. Good
luck with that.

Please answer the following questions for yourself before submitting a pull request. **YOU MAY DELETE UNUSED SECTIONS.**

# Rule Submission

Website: oglaf.com

* [x] I have made the rule as simple as possible ( K.I.S.S )
* [x] I have run the rule myself for a period of time to spot any bugs