### PR TITLE
Fix the heise.de recipe and make Bilderstrecken show the first image.

### DIFF
--- a/general/heise.de.json
+++ b/general/heise.de.json
@@ -10,8 +10,8 @@
                 "reformat": [
                         {
                                 "type": "regex",
-                                "pattern": "\/html$\/",
-                                "replace": "html?seite=all"
+                                "pattern": "\/\\.html\/",
+                                "replace": ".html?seite=all"
                         }
                 ],
                 "modify": [
@@ -22,7 +22,7 @@
                         },
                         {
                                 "type": "regex",
-                                "pattern": "\/<.?a-lightbox[^>]*?>\/",
+                                "pattern": "\/<.?a-(lightbox|bilderstrecke)[^>]*?>\/",
                                 "replace": ""
                         }
                 ],


### PR DESCRIPTION
Turns out, the feed always has something after the .html url, so the
match didn't always stick. This now should force ?seite=all more
consistently.

Also, drop the <a-bilderstrecke> tags which would hide the <img src>
tags within from being displayed, especially on the Android app.

Unlike the arstechnica hack, this does not show all images, but at least
the first one plus caption is visible and the user can decide to open
the full article in the browser or not.

Please answer the following questions for yourself before submitting a pull request. **YOU MAY DELETE UNUSED SECTIONS.**

# Recipe Submission

Website: heise.de

* [x] I have made the Recipe as simple as possible ( K.I.S.S )
* [x] I have run the Recipe myself for a period of time to spot any bugs
